### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,9 +1,9 @@
-A4990DualMotorDriverCarrier KEYWORD1
+A4990DualMotorDriverCarrier	KEYWORD1
 
-flipM1 KEYWORD2
-flipM2 KEYWORD2
-setM1Speed KEYWORD2
-setM2Speed KEYWORD2
-setSpeeds KEYWORD2
-getFault KEYWORD2
-errorHandling KEYWORD2
+flipM1	KEYWORD2
+flipM2	KEYWORD2
+setM1Speed	KEYWORD2
+setM2Speed	KEYWORD2
+setSpeeds	KEYWORD2
+getFault	KEYWORD2
+errorHandling	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords